### PR TITLE
Flat Route 

### DIFF
--- a/config/streamline.php
+++ b/config/streamline.php
@@ -3,7 +3,7 @@ return [
     'class_namespace' => 'App\\Streams',
     'class_postfix' => 'Stream',
     'route' => 'api/streamline',
-    'flat_route'=> 'api/streamline',
+    'flat_route'=> '',
     'middleware' => ['auth:sanctum'],
     'guest_streams' => [
         'auth/auth'

--- a/config/streamline.php
+++ b/config/streamline.php
@@ -3,7 +3,7 @@ return [
     'class_namespace' => 'App\\Streams',
     'class_postfix' => 'Stream',
     'route' => 'api/streamline',
-    'flat_route'=> '',
+    'flat_route'=> 'api/streamline',
     'middleware' => ['auth:sanctum'],
     'guest_streams' => [
         'auth/auth'

--- a/config/streamline.php
+++ b/config/streamline.php
@@ -3,6 +3,7 @@ return [
     'class_namespace' => 'App\\Streams',
     'class_postfix' => 'Stream',
     'route' => 'api/streamline',
+    'flat_route'=> 'api/streamline',
     'middleware' => ['auth:sanctum'],
     'guest_streams' => [
         'auth/auth'

--- a/routes/streamline.route.php
+++ b/routes/streamline.route.php
@@ -8,3 +8,10 @@ Route::group(['prefix' => $prefix], function () {
     Route::post('/',[\Iankibet\Streamline\Features\Streamline\HandleStreamlineRequest::class, 'handleRequest']);
     Route::get('/',[\Iankibet\Streamline\Features\Streamline\HandleStreamlineRequest::class, 'handleRequest']);
 });
+
+$flatRoute = config('streamline.flat_route', 'api/streamline');
+
+Route::group(['prefix' => $flatRoute], function () {
+    Route::post('/{arg1?}/{arg3?}/{arg4?}/{arg5?}/{arg6?}/{arg7?}',[\Iankibet\Streamline\Features\Streamline\HandleStreamlineRequest::class, 'handleFlatRequest']);
+    Route::get('/{arg1?}/{arg3?}/{arg4?}/{arg5?}/{arg6?}/{arg7?}',[\Iankibet\Streamline\Features\Streamline\HandleStreamlineRequest::class, 'handleFlatRequest']);
+});

--- a/routes/streamline.route.php
+++ b/routes/streamline.route.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 
-$prefix = config('streamline.route', 'streamline');
+$prefix = config('streamline.route', 'api/streamline');
 
 Route::group(['prefix' => $prefix], function () {
     Route::post('/',[\Iankibet\Streamline\Features\Streamline\HandleStreamlineRequest::class, 'handleRequest']);
@@ -12,6 +12,7 @@ Route::group(['prefix' => $prefix], function () {
 $flatRoute = config('streamline.flat_route', 'api/streamline');
 
 Route::group(['prefix' => $flatRoute], function () {
-    Route::post('/{arg1?}/{arg3?}/{arg4?}/{arg5?}/{arg6?}/{arg7?}',[\Iankibet\Streamline\Features\Streamline\HandleStreamlineRequest::class, 'handleFlatRequest']);
-    Route::get('/{arg1?}/{arg3?}/{arg4?}/{arg5?}/{arg6?}/{arg7?}',[\Iankibet\Streamline\Features\Streamline\HandleStreamlineRequest::class, 'handleFlatRequest']);
+    $routeString = '/{arg1?}/{arg2?}/{arg3?}/{arg4?}/{arg5?}/{arg6?}/{arg7?}';
+    Route::post($routeString,[\Iankibet\Streamline\Features\Streamline\HandleStreamlineRequest::class, 'handleFlatRequest']);
+    Route::get($routeString,[\Iankibet\Streamline\Features\Streamline\HandleStreamlineRequest::class, 'handleFlatRequest']);
 });

--- a/src/Features/Streamline/HandleStreamlineRequest.php
+++ b/src/Features/Streamline/HandleStreamlineRequest.php
@@ -19,14 +19,12 @@ class HandleStreamlineRequest extends Controller implements HasMiddleware
 
     public function handleFlatRequest(){
         $args = func_get_args();
-        $argsCollection = collect($args);
-        $lastItem = $argsCollection->last();
         // e.g users/user/1 results in users stream, user function
         // users/list-active results in users stream listActive
         // users/list/active - can be users stream, list function, active is param
         $streamArr = [];
         $streamStr = '';
-        foreach ($argsCollection as $arg) {
+        foreach ($args as $arg) {
             $streamArr[] = $arg;
             $streamStr = implode('/', $streamArr);
             $class = StreamlineSupport::convertStreamToClass($streamStr);
@@ -35,13 +33,17 @@ class HandleStreamlineRequest extends Controller implements HasMiddleware
             }
         }
         $remainingArgs = array_diff($args, $streamArr);
-        $action = array_pop($remainingArgs);
-        dd($action, $remainingArgs, $streamStr);
+        if(!$remainingArgs){
+            $action = 'onMounted';
+        } else {
+            $action = array_pop($remainingArgs);
+        }
         \request()->merge([
             'stream'=>$streamStr,
             'action'=>$action,
             'params' => $remainingArgs
         ]);
+        return $this->handleRequest(request());
     }
 
     public function handleRequest(Request $request)

--- a/src/Features/Streamline/HandleStreamlineRequest.php
+++ b/src/Features/Streamline/HandleStreamlineRequest.php
@@ -38,6 +38,9 @@ class HandleStreamlineRequest extends Controller implements HasMiddleware
         } else {
             $action = array_pop($remainingArgs);
         }
+        $action = Str::studly($action);
+        // lowercase first letter
+        $action = lcfirst($action);
         \request()->merge([
             'stream'=>$streamStr,
             'action'=>$action,

--- a/src/Features/Support/StreamlineSupport.php
+++ b/src/Features/Support/StreamlineSupport.php
@@ -17,7 +17,13 @@ class StreamlineSupport
         if (str_ends_with($stream, $classPostfix)) {
             $classPostfix = '';
         }
-        return config('streamline.class_namespace') . '\\' . $stream . $classPostfix;
+        $class = config('streamline.class_namespace') . '\\' . $stream . $classPostfix;
+        if(!class_exists($class)) {
+           $lastItem = $streamCollection->last();
+           $stream .= '\\' . Str::studly(str_replace('-', ' ', $lastItem));
+           $class = config('streamline.class_namespace') . '\\' . $stream . $class;
+        }
+        return $class;
     }
 
     public static function getStreamlineClasses(): array

--- a/src/Features/Support/StreamlineSupport.php
+++ b/src/Features/Support/StreamlineSupport.php
@@ -18,11 +18,11 @@ class StreamlineSupport
             $classPostfix = '';
         }
         $class = config('streamline.class_namespace') . '\\' . $stream . $classPostfix;
-        if(!class_exists($class)) {
-           $lastItem = $streamCollection->last();
-           $stream .= '\\' . Str::studly(str_replace('-', ' ', $lastItem));
-           $class = config('streamline.class_namespace') . '\\' . $stream . $class;
-        }
+//        if(!class_exists($class)) {
+//           $lastItem = $streamCollection->last();
+//           $stream .= '\\' . Str::studly(str_replace('-', ' ', $lastItem));
+//           $class = config('streamline.class_namespace') . '\\' . $stream . $class;
+//        }
         return $class;
     }
 

--- a/src/Features/Support/StreamlineSupport.php
+++ b/src/Features/Support/StreamlineSupport.php
@@ -18,11 +18,11 @@ class StreamlineSupport
             $classPostfix = '';
         }
         $class = config('streamline.class_namespace') . '\\' . $stream . $classPostfix;
-//        if(!class_exists($class)) {
-//           $lastItem = $streamCollection->last();
-//           $stream .= '\\' . Str::studly(str_replace('-', ' ', $lastItem));
-//           $class = config('streamline.class_namespace') . '\\' . $stream . $class;
-//        }
+        if(!class_exists($class)) {
+           $lastItem = $streamCollection->last();
+           $stream .= '\\' . Str::studly(str_replace('-', ' ', $lastItem));
+           $class = config('streamline.class_namespace') . '\\' . $stream . $classPostfix;
+        }
         return $class;
     }
 


### PR DESCRIPTION
Added a way to flatten streamline action

e.g Tasks stream with listTasks method can be called by

/api/streamline/tasks/list-tasks results to Tasks::listTasks

Resolved stream where class name is same as folder

e.g tasks/list-tasks can resolve to Tasks::listTasks or Tasks/Tasks::listTasks to avoid repetitive namespacing 